### PR TITLE
Fixing two issues with this tutorial

### DIFF
--- a/docs/docs/adding-tags-and-categories-to-blog-posts.md
+++ b/docs/docs/adding-tags-and-categories-to-blog-posts.md
@@ -54,8 +54,11 @@ Try running the following query in Graph<em>i</em>QL (`localhost:8000/___graphql
   ) {
     edges {
       node {
+        fields
+        {
+          slug
+        }
         frontmatter {
-          path
           tags
         }
       }
@@ -64,7 +67,7 @@ Try running the following query in Graph<em>i</em>QL (`localhost:8000/___graphql
 }
 ```
 
-The resulting data includes the `path` and `tags` frontmatter for each post, which is all the data we'll need to create pages for each tag which contain a list of posts under that tag. Let's make the tag page template now:
+The resulting data includes the `slug` field and `tags` frontmatter for each post, which is all the data we'll need to create pages for each tag which contain a list of posts under that tag. Let's make the tag page template now:
 
 ## Make a tags page template (for `/tags/{tag}`)
 
@@ -91,10 +94,11 @@ const Tags = ({ pageContext, data }) => {
       <h1>{tagHeader}</h1>
       <ul>
         {edges.map(({ node }) => {
-          const { path, title } = node.frontmatter
+          const { slug } = node.fields
+          const { title } = node.frontmatter
           return (
-            <li key={path}>
-              <Link to={path}>{title}</Link>
+            <li key={slug}>
+              <Link to={slug}>{title}</Link>
             </li>
           )
         })}
@@ -119,9 +123,11 @@ Tags.propTypes = {
         PropTypes.shape({
           node: PropTypes.shape({
             frontmatter: PropTypes.shape({
-              path: PropTypes.string.isRequired,
               title: PropTypes.string.isRequired,
             }),
+            fields: PropTypes.shape({
+              slug: PropTypes.string.isRequired,
+            })
           }),
         }).isRequired
       ),
@@ -141,9 +147,11 @@ export const pageQuery = graphql`
       totalCount
       edges {
         node {
+          fields {
+            slug
+          }
           frontmatter {
             title
-            path
           }
         }
       }
@@ -176,8 +184,11 @@ exports.createPages = ({ actions, graphql }) => {
       ) {
         edges {
           node {
+            fields
+            {
+              slug
+            }
             frontmatter {
-              path
               tags
             }
           }
@@ -298,7 +309,6 @@ export const pageQuery = graphql`
     }
     allMarkdownRemark(
       limit: 2000
-      filter: { frontmatter: { published: { ne: false } } }
     ) {
       group(field: frontmatter___tags) {
         fieldValue


### PR DESCRIPTION
I was trying to follow the tutorial, but consistently had GraphQL errors when trying to query frontmatter.path. @jlengstorf mentioned that this was a bug.

Updated the calls and this works as per https://github.com/shinytoyrobots/shinytoyrobots-dotcom/pull/5 on my site. Have updated the tutorial to reflect this.

Also removed line `filter: { frontmatter: { published: { ne: false } } }` from GraphQL query in tutorial section on creating a Tags index page. This only threw errors and compile failure for me, and this specific documentation page does not appear to be dependent on any other previous tutorial which has required a `published` field, so it seemed unnecessary that it be there.

<!--
  Have any questions? Check out the contributing docs at https://gatsby.dev/contribute, or
  ask in this Pull Request and a Gatsby maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
